### PR TITLE
Add notation for nested updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Definition setAB a b x := set B b (set A a x).
 (* you can also use a notation for the same thing: *)
 Import RecordSetNotations.
 Definition setAB' a b x := x <|A := a|> <|B := b|>.
+
+(* the notation also allows you to update nested fields: *)
+Record C := mkC { n : nat }.
+Record B := mkB { c : C }.
+Record A := mkA { b : B }.
+
+Instance etaC : Settable _ := settable! mkC<n>.
+Instance etaB : Settable _ := settable! mkB<c>.
+Instance etaA : Settable _ := settable! mkA<b>.
+
+Definition setNested n' x := x <| b; c; n := n' |>.
+Definition incNested x := x <| b; c; n ::= S |>.
 ```
 
 Coq has no record update syntax, nor does it create updaters for setting individual fields of a record. This small library automates creating such updaters.

--- a/src/RecordSet.v
+++ b/src/RecordSet.v
@@ -111,4 +111,10 @@ Module RecordSetNotations.
                                     (at level 12, left associativity) : record_set.
   Notation "x <| proj  ::=  f |>" := (set proj f x)
                                      (at level 12, f at next level, left associativity) : record_set.
+  Notation "x <| proj1 ; proj2 ; .. ; projn := v |>" :=
+    (set proj1 (set proj2 .. (set projn (fun _ => v)) ..) x)
+    (at level 12, left associativity) : record_set.
+  Notation "x <| proj1 ; proj2 ; .. ; projn ::= f |>" :=
+    (set proj1 (set proj2 .. (set projn f) ..) x)
+    (at level 12, f at next level, left associativity) : record_set.
 End RecordSetNotations.

--- a/src/RecordSetTests.v
+++ b/src/RecordSetTests.v
@@ -76,3 +76,16 @@ Module DependentWfExample.
     apply _.
   Qed.
 End DependentWfExample.
+
+Module NestedExample.
+  Record C := mkC { n : nat }.
+  Record B := mkB { c : C }.
+  Record A := mkA { b : B }.
+  
+  Instance etaC : Settable _ := settable! mkC<n>.
+  Instance etaB : Settable _ := settable! mkB<c>.
+  Instance etaA : Settable _ := settable! mkA<b>.
+  
+  Import RecordSetNotations.
+  Definition setNested n' x := x <| b; c; n := n' |>.
+End NestedExample.


### PR DESCRIPTION
Allow x <| a; b; c := n |> to update x.(a).(b).(c).

Closes #7.