### PR TITLE
fix opam and dune files, update meta.yml

### DIFF
--- a/coq-record-update.opam
+++ b/coq-record-update.opam
@@ -2,12 +2,12 @@ opam-version: "2.0"
 maintainer: "tchajed@gmail.com"
 version: "dev"
 
-homepage: "https://github.com/tchajed/record-update"
-dev-repo: "git+https://github.com/tchajed/record-update.git"
-bug-reports: "https://github.com/tchajed/record-update/issues"
+homepage: "https://github.com/tchajed/coq-record-update"
+dev-repo: "git+https://github.com/tchajed/coq-record-update.git"
+bug-reports: "https://github.com/tchajed/coq-record-update/issues"
 license: "MIT"
 
-synopsis: "Generic support for updating record fields"
+synopsis: "Generic support for updating record fields in Coq"
 description: """
 While Coq provides projections for each field of a record, it has no
 convenient way to update a single field of a record. This library provides a

--- a/dune
+++ b/dune
@@ -1,4 +1,0 @@
-(coq.theory
- (name RecordUpdate)
- (package coq-record-update)
- (synopsis "Generic support for updating record fields"))

--- a/meta.yml
+++ b/meta.yml
@@ -1,13 +1,14 @@
 ---
 fullname: Record Update
-shortname: record-update
+shortname: coq-record-update
+opam_name: coq-record-update
 organization: tchajed
 community: false
 travis: true
 coqdoc: false
 
 synopsis: >-
-  Generic support for updating record fields
+  Generic support for updating record fields in Coq
 
 description: |-
   While Coq provides projections for each field of a record, it has no
@@ -30,7 +31,6 @@ opam-file-version: dev
 license:
   fullname: MIT License
   identifier: MIT
-  file: LICENSE
 
 supported_coq_versions:
   text: 8.8 or later
@@ -44,8 +44,6 @@ tested_coq_opam_versions:
 - version: '8.9'
 - version: '8.8'
 
-dependencies:
-- description: none
 namespace: RecordUpdate
 
 keywords:

--- a/src/dune
+++ b/src/dune
@@ -1,0 +1,5 @@
+(coq.theory
+ (name RecordUpdate)
+ (package coq-record-update)
+ (synopsis "Generic support for updating record fields in Coq")
+ (flags -w -undeclared-scope))


### PR DESCRIPTION
The URL of the homepage/dev-repo/bug-reports in the opam file is currently wrong, and the dune file doesn't allow building the Coq project with dune (`dune build`). This PR updates `meta.yml` with the right options to fix the (template-generated) opam file and manually modifies the dune file to work. I also did a tiny update to mention Coq in the synopsis, since this field may be used in contexts where it's not known that this is indeed a Coq-related project.