### PR TITLE
add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+*.sh   text eol=lf


### PR DESCRIPTION
to make fiat-crypto CI happy

According to @JasonGross:

```
This makes checkout and development on Windows easier, and
makes my job of adding a Windows CI runner to fiat-crypto
significantly easier.
```