### PR TITLE
[WIP] Dependent field updates?

### DIFF
--- a/src/Lens.v
+++ b/src/Lens.v
@@ -6,6 +6,8 @@ function to define a field lens based on the [Setter] typeclass. This isn't as
 convenient to use, since we can't generate a lens per field without the kind of
 metaprograming in meta-coq or using a Coq plugin. *)
 
+(* TODO change argument order
+
 Record Lens A1 A2 T1 T2 :=
   mkLens { view : A1 -> T1;
            over : (T1 -> T2) -> (A1 -> A2);
@@ -24,3 +26,5 @@ Definition lens_compose {A1 A2 T1 T2 C1 C2}
   {| view x := view l2 (view l1 x);
      over f := over l1 (over l2 f);
   |}.
+
+*)

--- a/src/RecordSet.v
+++ b/src/RecordSet.v
@@ -31,11 +31,11 @@ Local Ltac setter etaT proj :=
   | context[proj] => idtac
   | _ => fail 1 proj "is not a field"
   end;
-  let set :=
-      (match eval pattern proj in etaT with
-       | ?setter _ => constr:(fun f => setter (fun r => f (proj r)))
-       end) in
-  exact set.
+  let y := fresh "y" in intro y;
+  let etaTy := eval cbv beta in (etaT y) in
+  match eval pattern (proj y) in etaTy with
+  | ?setter _ => exact (fun fieldUpdater => setter (fieldUpdater (proj y)))
+  end.
 
 (* Combining the above, [getSetter'] looks up the eta-expanded version of T with
 the Settable typeclass, and calls [setter] to create a setter. *)
@@ -52,13 +52,13 @@ Local Ltac get_setter T proj :=
 (* Setter provides a way to change a field given by a projection function, along
 with correctness conditions that require the projected field and only the
 projected field is modified. *)
-Class Setter {R T} (proj: R -> T) := set : (T -> T) -> R -> R.
+Class Setter {R: Type} {T: R -> Type} (proj: forall r, T r) := set : forall r: R, (T r -> T r) -> R.
 Arguments set {R T} proj {Setter}.
 
 Class SetterWf {R T} (proj: R -> T) :=
   { set_wf :> Setter proj;
-    set_get: forall v r, proj (set proj v r) = v (proj r);
-    set_eq: forall f r, f (proj r) = proj r -> set proj f r = r; }.
+    set_get: forall r v, proj (set proj r v) = v (proj r);
+    set_eq: forall f r, f (proj r) = proj r -> set proj r f = r; }.
 
 Arguments set_wf {R T} proj {SetterWf}.
 
@@ -73,10 +73,9 @@ Local Ltac SetterWfInstance_t :=
     unshelve notypeclasses refine (Build_SetterWf _ _ _);
     [ get_setter T A |
       let r := fresh in
-      intros ? r; destruct r; reflexivity |
-      let f := fresh in
+      intros r ?; destruct r; reflexivity |
       let r := fresh in
-      intros f r; destruct r; cbv; congruence ]
+      intros ? r; destruct r; cbv; congruence ]
   end.
 
 Global Hint Extern 1 (Setter _) => SetterInstance_t : typeclass_instances.
@@ -86,9 +85,9 @@ Module RecordSetNotations.
   Declare Scope record_set.
   Delimit Scope record_set with rs.
   Open Scope rs.
-  Notation "x <| proj  ::=  f |>" := (set proj f x)
+  Notation "x <| proj  ::=  f |>" := (set proj x f)
                                      (at level 12, f at next level, left associativity) : record_set.
-  Notation "x <| proj  :=  v |>" := (set proj (fun _ => v) x)
+  Notation "x <| proj  :=  v |>" := (set proj x (fun _ => v))
                                     (at level 12, left associativity) : record_set.
   Notation "x <| proj1 ; proj2 ; .. ; projn ::= f |>" :=
     (set proj1 (set proj2 .. (set projn f) ..) x)

--- a/tests/LensTests.v
+++ b/tests/LensTests.v
@@ -3,6 +3,7 @@ From RecordUpdate Require Import RecordUpdate Lens.
 Record X := mkX { A: nat; B: nat; C: bool; }.
 Instance etaX : Settable _ := settable! mkX <A; B; C>.
 
+(* TODO
 (* lenses require much more boilerplate than setters (if you want them to look
 like Haskell lenses) *)
 Definition _A := field_lens A.
@@ -10,3 +11,4 @@ Definition _B := field_lens B.
 Definition _C := field_lens C.
 
 Definition set_A_to_3 (x:X) := over _A (fun _ => 3) x.
+*)

--- a/tests/PrintingTests.v
+++ b/tests/PrintingTests.v
@@ -12,8 +12,10 @@ Print updateA.
 Record Nested := mkNested { anX: X; aNat: nat; }.
 Instance etaNested : Settable _ := settable! mkNested <anX; aNat>.
 
+(* TODO not clear whether nested updates can still work?
 Definition setXB (n:Nested) := n <|anX; B:=3|>.
 Print setXB.
 
 Definition updateXB (n:Nested) := n <|anX; B::=S|>.
 Print updateXB.
+*)

--- a/tests/ReadmeExampleTests.v
+++ b/tests/ReadmeExampleTests.v
@@ -6,7 +6,7 @@ Record X := mkX { A: nat; B: nat; C: bool; }.
 Instance etaX : Settable _ := settable! mkX <A; B; C>.
 
 (* and now you can update fields! *)
-Definition setAB a b x := set B b (set A a x).
+Definition setAB x a b := set B (set A x a) b.
 
 (* you can also use a notation for the same thing: *)
 Import RecordSetNotations.

--- a/tests/RecordSetTests.v
+++ b/tests/RecordSetTests.v
@@ -40,6 +40,10 @@ Module DependentExample.
 
   Import RecordSetNotations.
   Definition setB b x := x <|B := b|>.
+
+  Definition setA_manually(x: X)(a: T x): X := @mkX (T x) a (B x).
+  Definition setA(x: X)(a: T x) := x <|A := a|>.
+
 End DependentExample.
 
 Module WellFormedExample.
@@ -50,7 +54,7 @@ Module WellFormedExample.
 
   Instance etaX : Settable _ := settable! mkX <A; B; C>.
 
-  Definition setAB a b x := set A (fun _ => a) (set B (fun _ => b) x).
+  Definition setAB a b x := set A (set B x (fun _ => b)) (fun _ => a).
 
   (* Resolving an instance for SetterWf proves some correctness properties of
   the setter. You can also require constructing this instance by accessing the
@@ -60,7 +64,7 @@ Module WellFormedExample.
     apply _.
   Qed.
 
-  Definition setAB_wf a b x := set_wf A (fun _ => a) (set_wf B (fun _ => b) x).
+  Definition setAB_wf a b x := set_wf A (set_wf B x (fun _ => b)) (fun _ => a).
 End WellFormedExample.
 
 Module DependentWfExample.
@@ -77,6 +81,7 @@ Module DependentWfExample.
   Qed.
 End DependentWfExample.
 
+(* TODO
 Module NestedExample.
   Record C := mkC { n : nat }.
   Record B := mkB { c : C }.
@@ -89,6 +94,7 @@ Module NestedExample.
   Import RecordSetNotations.
   Definition setNested n' x := x <| b; c; n := n' |>.
 End NestedExample.
+*)
 
 Module TypeParameterExample.
   Record X T := mkX { a: nat; b: T; c: T * T; }.

--- a/tests/RegressionTests.v
+++ b/tests/RegressionTests.v
@@ -16,7 +16,7 @@ Module GH5.
   Definition getA (x:X) := let 'mkX a := x in a.
 
   (* should not succeed, getA is not a projection *)
-  Fail Definition setA (r: X) (a: nat) := set getA (fun _ => a) r.
+  Fail Definition setA (r: X) (a: nat) := set getA r (fun _ => a).
 End GH5.
 
 Module GH10.

--- a/tests/coqpl_2021.v
+++ b/tests/coqpl_2021.v
@@ -4,22 +4,22 @@ Record X := mkX { A: nat; B: nat; C: bool }.
 (* you can omit the X; it's there to clarify the Settable class for the paper *)
 Instance: Settable X := settable! mkX <A; B; C>.
 
-Definition add3_to_B x := set B (plus 3) x.
-Definition setB_to_3 x := set B (fun _ => 3) x.
+Definition add3_to_B x := set B x (plus 3).
+Definition setB_to_3 x := set B x (fun _ => 3).
 Definition setB_to_3_notation x := x <|B:=3|>.
 
 Instance set_B : Setter B := _.
 
-Theorem set_B_convertible_to f x :
-  set_B f x =
+Theorem set_B_convertible_to x f :
+  set_B x f =
   let a := x.(A) in
   let b' := f x.(B) in
   let c := x.(C) in
   mkX a b' c.
 Proof. reflexivity. Qed.
 
-Theorem set_B_is f x :
-  set_B f x =
+Theorem set_B_is x f :
+  set_B x f =
   mkX x.(A) (f x.(B)) x.(C).
 Proof.
   unfold set_B.
@@ -31,7 +31,7 @@ Proof.
 Qed.
 
 Theorem simpl_behavior x :
-  (set A (fun _ => 2) (set B (fun _ => 3) x)).(B) = 3.
+  (set A (set B x (fun _ => 3)) (fun _ => 2)).(B) = 3.
 Proof.
   simpl.
   Show.
@@ -70,4 +70,4 @@ Instance: Settable _ := settable! Build_several_nats <nat1_synonym; nat2; nat3>.
 (* this no longer works because the Settable several_nats doesn't say anything
 about nat1 *)
 Fail Definition set_nat1 f (x: several_nats) := set nat1 f x.
-Definition set_nat1 f (x: several_nats) := set nat1_synonym f x.
+Definition set_nat1 (x: several_nats) f := set nat1_synonym x f.


### PR DESCRIPTION
Currently, in `RecordSetTests.DependentExample`, we can't typecheck

```coq
Definition setA(x: X)(a: T x) := x <|A := a|>.
```

because `set` only accepts non-dependent projections `(proj: R -> T)`.
This PR makes `set` accept projections with a dependent return type, `(proj: forall r: R, T r)`, so that `setA` above now typechecks.

It requires changing the argument order of `set` (the record needs to come before the field updater), because the type of the field updater depends on the record.

Also, I haven't figured out yet how to fix the recursive notation for nested updates...

Thoughts?