### PR TITLE
Add some Ltac to autogenerate Settable

### DIFF
--- a/tests/LensTests.v
+++ b/tests/LensTests.v
@@ -1,7 +1,7 @@
 From RecordUpdate Require Import RecordUpdate Lens.
 
 Record X := mkX { A: nat; B: nat; C: bool; }.
-Instance etaX : Settable _ := settable! mkX <A; B; C>.
+(*Instance etaX : Settable _ := settable! mkX <A; B; C>.*)
 
 (* lenses require much more boilerplate than setters (if you want them to look
 like Haskell lenses) *)

--- a/tests/ListNotationTests.v
+++ b/tests/ListNotationTests.v
@@ -9,9 +9,9 @@ Module GH4.
   Record foo := { a : bool ;
                   b : bool }.
 
-  Global Instance etaX_RtlExprs : Settable _ :=
+(*  Global Instance etaX_RtlExprs : Settable _ :=
     settable!
-            Build_foo <a; b>.
+            Build_foo <a; b>.*)
 
 
   Definition bar := {| a := true ; b := true |}.
@@ -23,5 +23,5 @@ Definition l := [1; 2; 3].
 Record foo := { a : list nat;
                 b : list bool; }.
 
-Instance eta_foo : Settable _ := settable! Build_foo <a; b>.
+(*Instance eta_foo : Settable _ := settable! Build_foo <a; b>.*)
 Definition m_foo (x:foo) := x <| a := [1;2;3] |> <| b := [] |>.

--- a/tests/PrintingTests.v
+++ b/tests/PrintingTests.v
@@ -1,7 +1,7 @@
 From RecordUpdate Require Import RecordUpdate.
 
 Record X := mkX { A: nat; B: nat; }.
-Instance etaX : Settable _ := settable! mkX <A; B>.
+(*Instance etaX : Settable _ := settable! mkX <A; B>.*)
 
 Definition setA (x:X) n := x <|B:=n|>.
 Print setA.
@@ -10,7 +10,7 @@ Definition updateA (x:X) n := x <|B::=Nat.add n|>.
 Print updateA.
 
 Record Nested := mkNested { anX: X; aNat: nat; }.
-Instance etaNested : Settable _ := settable! mkNested <anX; aNat>.
+(*Instance etaNested : Settable _ := settable! mkNested <anX; aNat>.*)
 
 Definition setXB (n:Nested) := n <|anX; B:=3|>.
 Print setXB.

--- a/tests/ReadmeExampleTests.v
+++ b/tests/ReadmeExampleTests.v
@@ -3,7 +3,7 @@ From RecordUpdate Require Import RecordSet.
 Record X := mkX { A: nat; B: nat; C: bool; }.
 
 (* all you need to do is provide something like this, listing out the fields of your record: *)
-Instance etaX : Settable _ := settable! mkX <A; B; C>.
+(*Instance etaX : Settable _ := settable! mkX <A; B; C>.*)
 
 (* and now you can update fields! *)
 Definition setAB a b x := set B b (set A a x).

--- a/tests/RecordSetTests.v
+++ b/tests/RecordSetTests.v
@@ -8,9 +8,10 @@ Module SimpleExample.
                     B: nat;
                     C: unit }.
 
-  Instance etaX : Settable _ := settable! mkX <A; B; C>.
+  (*Instance etaX : Settable X := _. (*settable! mkX <A; B; C>.*)*)
 
   Import RecordSetNotations.
+
   Definition setAB a b x := x <|A := a|> <|B := b|>.
   Definition updateAB a b x := x <|A ::= plus a|> <|B ::= minus b|>.
 
@@ -22,8 +23,8 @@ Module IndexedType.
                         C: unit }.
   Arguments X T : clear implicits.
 
-  Instance etaX T: Settable (X T) :=
-    settable! (mkX (T:=T)) < A; B; C>.
+  (*Instance etaX T: Settable (X T) :=
+    settable! (mkX (T:=T)) < A; B; C>.*)
 
   Import RecordSetNotations.
   Definition setAB T a b (x: X T) := x <|A := a|> <|B := b|>.
@@ -35,8 +36,8 @@ Module DependentExample.
                     A: T;
                     B: nat }.
 
-  Instance etaX : Settable X :=
-    settable! mkX <T; A; B>.
+  (*Instance etaX : Settable X :=
+    settable! mkX <T; A; B>.*)
 
   Import RecordSetNotations.
   Definition setB b x := x <|B := b|>.
@@ -48,7 +49,7 @@ Module WellFormedExample.
                     B: nat;
                     C: unit }.
 
-  Instance etaX : Settable _ := settable! mkX <A; B; C>.
+  (*Instance etaX : Settable _ := settable! mkX <A; B; C>.*)
 
   Definition setAB a b x := set A (fun _ => a) (set B (fun _ => b) x).
 
@@ -68,8 +69,8 @@ Module DependentWfExample.
                     A: T;
                     B: nat }.
 
-  Instance etaX : Settable X :=
-    settable! mkX <T; A; B>.
+  (*Instance etaX : Settable X :=
+    settable! mkX <T; A; B>.*)
 
   Instance set_A : SetterWf B.
   Proof.
@@ -110,7 +111,7 @@ Module TypeParameterLimitation.
   Arguments a {T}.
   Arguments b {T}.
 
-  Instance etaX T : Settable _ := settable! (@mkX T) <a;b>.
+  (*Instance etaX T : Settable _ := settable! (@mkX T) <a;b>.*)
 
   Import RecordSetNotations.
   Definition set_a (x:X unit) := x <| a := 3 |>.

--- a/tests/RegressionTests.ref
+++ b/tests/RegressionTests.ref
@@ -1,11 +1,3 @@
-The command has indeed failed with message:
-The following term contains unresolved implicit arguments:
-  (fun (r : X) (a : nat) => r <| getA := a |>)
-More precisely: 
-- ?Setter: Cannot infer the implicit parameter Setter of set whose type is
-  "Setter getA" (no type class instance found) in environment:
-  r : X
-  a : nat
 test = 
 fun (s : ThreadState) (newRegs : Registers) => s <| Regs := newRegs |>
      : ThreadState -> Registers -> ThreadState

--- a/tests/RegressionTests.v
+++ b/tests/RegressionTests.v
@@ -3,7 +3,7 @@ From RecordUpdate Require Import RecordUpdate.
 Module GH2.
   Record X := mkX { A: nat;}.
 
-  Instance etaX : Settable _ := settable! mkX <A>.
+  (*Instance etaX : Settable _ := settable! mkX <A>.*)
 
   (* name r should not prevent finding a Setter A instance *)
   Definition setA (r : nat) x := x <|A := 32|>.
@@ -11,17 +11,18 @@ End GH2.
 
 Module GH5.
   Record X := mkX { A: nat; }.
-  Instance etaX : Settable _ := settable! mkX <A>.
+  (*Instance etaX : Settable _ := settable! mkX <A>.*)
 
   Definition getA (x:X) := let 'mkX a := x in a.
 
   (* should not succeed, getA is not a projection *)
-  Fail Definition setA (r: X) (a: nat) := set getA (fun _ => a) r.
+  (* XXX Should it succeed? *)
+  Definition setA (r: X) (a: nat) := set getA (fun _ => a) r.
 End GH5.
 
 Module GH10.
   Record X := mkX { A: nat; B: nat; x: bool; }.
-  Instance etaX : Settable _ := settable! mkX <A; B; x>.
+  Instance etaX : Settable X := _. (*settable! mkX <A; B; x>.*)
 End GH10.
 
 Module GH13.
@@ -33,7 +34,7 @@ Module GH13.
                             Pc: word;
                           }.
 
-  Instance ThreadStateSettable : Settable ThreadState := settable! mkThreadState <Regs; Pc>.
+  (*Instance ThreadStateSettable : Settable ThreadState := settable! mkThreadState <Regs; Pc>.*)
 
   Definition test(s: ThreadState)(newRegs: Registers): ThreadState := s <| Regs := newRegs |>.
 

--- a/tests/coqpl_2021.ref
+++ b/tests/coqpl_2021.ref
@@ -3,8 +3,10 @@
   f : nat -> nat
   x : X
   ============================
-  {| A := A x; B := f (B x); C := C x |} =
-  {| A := A x; B := f (B x); C := C x |}
+  {|
+  A := let (A0, _, _) := x in A0;
+  B := f (B x);
+  C := let (_, _, C0) := x in C0 |} = {| A := A x; B := f (B x); C := C x |}
 1 goal
   
   x : X
@@ -32,12 +34,3 @@ The command has indeed failed with message:
 Tactic failure: incorrect settable! declaration (perhaps fields are out-of-order?).
 The command has indeed failed with message:
 Tactic failure: incorrect settable! declaration (perhaps fields are out-of-order?).
-The command has indeed failed with message:
-The following term contains unresolved implicit arguments:
-  (fun (f : nat -> nat) (x : several_nats) => x <| nat1 ::= f |>)
-More precisely: 
-- ?Setter: Cannot infer the implicit parameter Setter of set whose type is
-  "Setter nat1" (no type class instance found) in
-  environment:
-  f : nat -> nat
-  x : several_nats

--- a/tests/coqpl_2021.v
+++ b/tests/coqpl_2021.v
@@ -24,6 +24,7 @@ Theorem set_B_is f x :
 Proof.
   unfold set_B.
   Show.
+  cbv.
   match goal with
   | |- ?x = ?x => reflexivity
   | _ => fail 1 "not an exact match"
@@ -43,7 +44,7 @@ Qed.
 
 Fail Definition error_not_field := set plus.
 
-Definition get_A x := A x.
+Definition get_A (x : X) := 5.
 (* the Ltac produces a better error message, but typeclass resolution swallows
 up the error *)
 Fail Definition error_not_proj := set get_A.
@@ -69,5 +70,5 @@ Instance: Settable _ := settable! Build_several_nats <nat1_synonym; nat2; nat3>.
 
 (* this no longer works because the Settable several_nats doesn't say anything
 about nat1 *)
-Fail Definition set_nat1 f (x: several_nats) := set nat1 f x.
-Definition set_nat1 f (x: several_nats) := set nat1_synonym f x.
+Definition set_nat1 f (x: several_nats) := set nat1 f x.
+Definition set_nat1' f (x: several_nats) := set nat1_synonym f x.


### PR DESCRIPTION
Note that field-setting is up to unification, and so we fully normalize
the type of the record when generating the instance.  This will be very
slow for large record types.  Finally, the term generated by setting a
field will use unfolded projections, which may be more ugly.  The
combination of these suggests that you may not want to include this, or
you may want to make this optional.