### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+# copied from fiat-crypto's .gitattributes for Windows compatibility
+
 * text=auto
 
 *.sh   text eol=lf


### PR DESCRIPTION
This is required for use as a dependency of fiat-crypto, because we
check that `git diff` reports empty after the build, even on Windows,
and Windows will report a bunch of changed line endings if we don't
include this.