### PR TITLE
Patch to use `$(MAKE)` instead of `make`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@
 
 # Forward most targets to Coq makefile (with some trick to make this phony)
 %: Makefile.coq phony
-	+@make -f Makefile.coq $@
+	+@$(MAKE) -f Makefile.coq $@
 
 all: Makefile.coq
-	+@make -f Makefile.coq all
+	+@$(MAKE) -f Makefile.coq all
 .PHONY: all
 
 clean: Makefile.coq
-	+@make -f Makefile.coq clean
+	+@$(MAKE) -f Makefile.coq clean
 	find src tests \( -name "*.d" -o -name "*.vo" -o -name "*.vo[sk]" -o -name "*.aux" -o -name "*.cache" -o -name "*.glob" -o -name "*.vio" \) -print -delete || true
 	rm -f Makefile.coq .lia.cache
 .PHONY: clean


### PR DESCRIPTION
Some systems (such as OpenBSD) use BSD make by default, and package
GNU make separately as `gmake`. The current makefile recursively
calls `Makefile.coq` using an explicit `make` command, which causes
makefile parsing errors on systems that default to BSD make.

The magic `$(MAKE)` variable allows make to recurse using the same
command it was invoked with.

Thank you for this package!