### PR TITLE
Adapt to Coq PR #14596: The "Arguments" line is now always printed with Print/About

### DIFF
--- a/tests/PrintingTests.ref
+++ b/tests/PrintingTests.ref
@@ -1,7 +1,7 @@
 setA = fun (x : X) (n : nat) => x <| B := n |>
      : X -> nat -> X
 
-Arguments setA _ _%nat_scope
+Arguments setA x n%nat_scope
 updateA = 
 fun (x : X) (n : nat) => x <| B ::= Nat.add n |>
      : X -> nat -> X
@@ -9,5 +9,9 @@ fun (x : X) (n : nat) => x <| B ::= Nat.add n |>
 Arguments updateA _ _%nat_scope
 setXB = fun n : Nested => n <| anX; B := 3 |>
      : Nested -> Nested
+
+Arguments setXB n
 updateXB = fun n : Nested => n <| anX; B ::= S |>
      : Nested -> Nested
+
+Arguments updateXB n

--- a/tests/RegressionTests.ref
+++ b/tests/RegressionTests.ref
@@ -9,3 +9,5 @@ More precisely:
 test = 
 fun (s : ThreadState) (newRegs : Registers) => s <| Regs := newRegs |>
      : ThreadState -> Registers -> ThreadState
+
+Arguments test s newRegs


### PR DESCRIPTION
Hi, coq-record-update is a submodule of bedrock2. This PR adapts coq-record-update's tests to Coq's PR coq/coq#14596 which adds a printing of names in the `Argument` line of `About` and `Print`. 

I assume that this PR is ok to you. If it is so, it will have to be merged synchronously with coq/coq#14596 to preserve the consistency of Coq CI.
