### PR TITLE
Allow coq 8.14 in opam file

### DIFF
--- a/coq-record-update.opam
+++ b/coq-record-update.opam
@@ -17,7 +17,7 @@ simple typeclass that lists out the record fields."""
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.9" & < "8.14~") | (= "dev")}
+  "coq" {(>= "8.9" & < "8.15~") | (= "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
This PR allows coq-record-update to build against coq 8.14 (which will hopefully be released soon). There is no `coqorg/coq:8.14` image yet so I could not add coq 8.14 to the CI.