### PR TITLE
add record-style update syntax

### DIFF
--- a/src/RecordSet.v
+++ b/src/RecordSet.v
@@ -86,14 +86,22 @@ Module RecordSetNotations.
   Declare Scope record_set.
   Delimit Scope record_set with rs.
   Open Scope rs.
-  Notation "x <| proj  ::=  f |>" := (set proj f x)
-                                     (at level 12, f at next level, left associativity) : record_set.
-  Notation "x <| proj  :=  v |>" := (set proj (fun _ => v) x)
-                                    (at level 12, left associativity) : record_set.
+  Notation "x <| proj  ::=  f |>" :=
+    (set proj f x)
+    (at level 12, proj at level 1, left associativity) : record_set.
+  Notation "x <| proj  :=  v |>" :=
+    (set proj (fun _ => v) x)
+      (at level 12, proj at level 1, left associativity) : record_set.
+  Notation "x <| proj v  :=  v' |>" :=
+    (set proj (fun v => v') x)
+    (at level 12, proj at level 1, left associativity, only parsing) : record_set.
   Notation "x <| proj1 ; proj2 ; .. ; projn ::= f |>" :=
     (set proj1 (set proj2 .. (set projn f) ..) x)
-    (at level 12, f at next level, left associativity) : record_set.
+    (at level 12, proj1, proj2, projn at level 1, left associativity) : record_set.
   Notation "x <| proj1 ; proj2 ; .. ; projn := v |>" :=
     (set proj1 (set proj2 .. (set projn (fun _ => v)) ..) x)
-    (at level 12, left associativity) : record_set.
+      (at level 12, proj1, proj2, projn at level 1, left associativity) : record_set.
+  Notation "x <| proj1 ; proj2 ; .. ; projn v := v' |>" :=
+    (set proj1 (set proj2 .. (set projn (fun v => v')) ..) x)
+    (at level 12, proj1, proj2, projn at level 1, left associativity, only parsing) : record_set.
 End RecordSetNotations.

--- a/tests/RecordSetTests.v
+++ b/tests/RecordSetTests.v
@@ -13,6 +13,7 @@ Module SimpleExample.
   Import RecordSetNotations.
   Definition setAB a b x := x <|A := a|> <|B := b|>.
   Definition updateAB a b x := x <|A ::= plus a|> <|B ::= minus b|>.
+  Definition updateAB' a b x := x <|A x := plus a x|> <|B y := minus b y|>.
 
 End SimpleExample.
 
@@ -88,6 +89,8 @@ Module NestedExample.
 
   Import RecordSetNotations.
   Definition setNested n' x := x <| b; c; n := n' |>.
+  Definition updateNested n' x := x <| b; c; n ::= plus n' |>.
+  Definition updateNested' n' x := x <| b; c; n m := plus n' m |>.
 End NestedExample.
 
 Module TypeParameterExample.


### PR DESCRIPTION
This MR adds update syntax similar to the syntax offered for record creation when storing functions. Instead of writing
```coq
x<| field ::= fun n => plus m n |> 
```
you can now write 
```coq
x<| field n := plus m n |> 
```
It can be quite convenient when the update you're trying to apply cannot be easily curried (e.g. due to other notation). 

Custom Coq notation is still a bit black magic to me (in particular which levels to use...) but all tests pass and it seems to work as intended. I've added the new syntax as `only parsing` to cause the least amount of disruption. 