### PR TITLE
Add export attribute to all instances

### DIFF
--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -27,7 +27,7 @@ jobs:
           - '8.10'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: coq-community/docker-coq-action@v1
         with:
           opam_file: 'coq-record-update.opam'

--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -6,8 +6,6 @@ on:
       - master
     tags: '*'
   pull_request:
-    branches:
-      - '**'
   schedule:
     # Tuesday 8am UTC (3am EST)
     - cron: '0 8 * * TUE'

--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         coq_image:
           - 'dev-ocaml-4.12-flambda'
+          - '8.16'
           - '8.15'
           - '8.14'
           - '8.13'

--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -21,10 +21,6 @@ jobs:
           - '8.16'
           - '8.15'
           - '8.14'
-          - '8.13'
-          - '8.12'
-          - '8.11'
-          - '8.10'
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ From RecordUpdate Require Import RecordSet.
 Record X := mkX { A: nat; B: nat; C: bool; }.
 
 (* all you need to do is provide something like this, listing out the fields of your record: *)
-Instance etaX : Settable _ := settable! mkX <A; B; C>.
+#[export] Instance etaX : Settable _ := settable! mkX <A; B; C>.
 
 (* and now you can update fields! *)
 Definition setAB a b x := set B b (set A a x).

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,5 +1,5 @@
 -Q src RecordUpdate
--arg -w -arg -deprecated-instance-without-locality
+-arg -w -arg +deprecated-instance-without-locality
 -arg -w -arg +undeclared-scope
 src/RecordSet.v
 src/RecordUpdate.v

--- a/coq-record-update.opam
+++ b/coq-record-update.opam
@@ -20,7 +20,7 @@ simple typeclass that lists out the record fields."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.8" & < "8.17~") | (= "dev")}
+  "coq" {(>= "8.14" & < "8.17~") | (= "dev")}
 ]
 
 tags: [

--- a/tests/LensTests.v
+++ b/tests/LensTests.v
@@ -1,7 +1,7 @@
 From RecordUpdate Require Import RecordUpdate Lens.
 
 Record X := mkX { A: nat; B: nat; C: bool; }.
-Instance etaX : Settable _ := settable! mkX <A; B; C>.
+#[export] Instance etaX : Settable _ := settable! mkX <A; B; C>.
 
 (* lenses require much more boilerplate than setters (if you want them to look
 like Haskell lenses) *)

--- a/tests/ListNotationTests.v
+++ b/tests/ListNotationTests.v
@@ -23,5 +23,5 @@ Definition l := [1; 2; 3].
 Record foo := { a : list nat;
                 b : list bool; }.
 
-Instance eta_foo : Settable _ := settable! Build_foo <a; b>.
+#[export] Instance eta_foo : Settable _ := settable! Build_foo <a; b>.
 Definition m_foo (x:foo) := x <| a := [1;2;3] |> <| b := [] |>.

--- a/tests/PrintingTests.v
+++ b/tests/PrintingTests.v
@@ -1,7 +1,7 @@
 From RecordUpdate Require Import RecordUpdate.
 
 Record X := mkX { A: nat; B: nat; }.
-Instance etaX : Settable _ := settable! mkX <A; B>.
+#[export] Instance etaX : Settable _ := settable! mkX <A; B>.
 
 Definition setA (x:X) n := x <|B:=n|>.
 Print setA.
@@ -10,7 +10,7 @@ Definition updateA (x:X) n := x <|B::=Nat.add n|>.
 Print updateA.
 
 Record Nested := mkNested { anX: X; aNat: nat; }.
-Instance etaNested : Settable _ := settable! mkNested <anX; aNat>.
+#[export] Instance etaNested : Settable _ := settable! mkNested <anX; aNat>.
 
 Definition setXB (n:Nested) := n <|anX; B:=3|>.
 Print setXB.

--- a/tests/ReadmeExampleTests.v
+++ b/tests/ReadmeExampleTests.v
@@ -3,7 +3,7 @@ From RecordUpdate Require Import RecordSet.
 Record X := mkX { A: nat; B: nat; C: bool; }.
 
 (* all you need to do is provide something like this, listing out the fields of your record: *)
-Instance etaX : Settable _ := settable! mkX <A; B; C>.
+#[export] Instance etaX : Settable _ := settable! mkX <A; B; C>.
 
 (* and now you can update fields! *)
 Definition setAB a b x := set B b (set A a x).

--- a/tests/RecordSetTests.v
+++ b/tests/RecordSetTests.v
@@ -8,7 +8,7 @@ Module SimpleExample.
                     B: nat;
                     C: unit }.
 
-  Instance etaX : Settable _ := settable! mkX <A; B; C>.
+  #[export] Instance etaX : Settable _ := settable! mkX <A; B; C>.
 
   Import RecordSetNotations.
   Definition setAB a b x := x <|A := a|> <|B := b|>.
@@ -22,7 +22,7 @@ Module IndexedType.
                         C: unit }.
   Arguments X T : clear implicits.
 
-  Instance etaX T: Settable (X T) :=
+  #[export] Instance etaX T: Settable (X T) :=
     settable! (mkX (T:=T)) < A; B; C>.
 
   Import RecordSetNotations.
@@ -35,7 +35,7 @@ Module DependentExample.
                     A: T;
                     B: nat }.
 
-  Instance etaX : Settable X :=
+  #[export] Instance etaX : Settable X :=
     settable! mkX <T; A; B>.
 
   Import RecordSetNotations.
@@ -48,14 +48,14 @@ Module WellFormedExample.
                     B: nat;
                     C: unit }.
 
-  Instance etaX : Settable _ := settable! mkX <A; B; C>.
+  #[export] Instance etaX : Settable _ := settable! mkX <A; B; C>.
 
   Definition setAB a b x := set A (fun _ => a) (set B (fun _ => b) x).
 
   (* Resolving an instance for SetterWf proves some correctness properties of
   the setter. You can also require constructing this instance by accessing the
   setter through set_wf. *)
-  Instance set_A : SetterWf A.
+  #[export] Instance set_A : SetterWf A.
   Proof.
     apply _.
   Qed.
@@ -68,10 +68,10 @@ Module DependentWfExample.
                     A: T;
                     B: nat }.
 
-  Instance etaX : Settable X :=
+  #[export] Instance etaX : Settable X :=
     settable! mkX <T; A; B>.
 
-  Instance set_A : SetterWf B.
+  #[export] Instance set_A : SetterWf B.
   Proof.
     apply _.
   Qed.
@@ -82,9 +82,9 @@ Module NestedExample.
   Record B := mkB { c : C }.
   Record A := mkA { b : B }.
 
-  Instance etaC : Settable _ := settable! mkC<n>.
-  Instance etaB : Settable _ := settable! mkB<c>.
-  Instance etaA : Settable _ := settable! mkA<b>.
+  #[export] Instance etaC : Settable _ := settable! mkC<n>.
+  #[export] Instance etaB : Settable _ := settable! mkB<c>.
+  #[export] Instance etaA : Settable _ := settable! mkA<b>.
 
   Import RecordSetNotations.
   Definition setNested n' x := x <| b; c; n := n' |>.
@@ -96,7 +96,7 @@ Module TypeParameterExample.
   Arguments b {T}.
   Arguments c {T}.
 
-  Instance etaX T : Settable _ := settable! (@mkX T) <a;b;c>.
+  #[export] Instance etaX T : Settable _ := settable! (@mkX T) <a;b;c>.
 
   Import RecordSetNotations.
   Definition set_a (x:X unit) := x <| a := 3 |>.
@@ -110,7 +110,7 @@ Module TypeParameterLimitation.
   Arguments a {T}.
   Arguments b {T}.
 
-  Instance etaX T : Settable _ := settable! (@mkX T) <a;b>.
+  #[export] Instance etaX T : Settable _ := settable! (@mkX T) <a;b>.
 
   Import RecordSetNotations.
   Definition set_a (x:X unit) := x <| a := 3 |>.

--- a/tests/RegressionTests.v
+++ b/tests/RegressionTests.v
@@ -3,7 +3,7 @@ From RecordUpdate Require Import RecordUpdate.
 Module GH2.
   Record X := mkX { A: nat;}.
 
-  Instance etaX : Settable _ := settable! mkX <A>.
+  #[export] Instance etaX : Settable _ := settable! mkX <A>.
 
   (* name r should not prevent finding a Setter A instance *)
   Definition setA (r : nat) x := x <|A := 32|>.
@@ -11,7 +11,7 @@ End GH2.
 
 Module GH5.
   Record X := mkX { A: nat; }.
-  Instance etaX : Settable _ := settable! mkX <A>.
+  #[export] Instance etaX : Settable _ := settable! mkX <A>.
 
   Definition getA (x:X) := let 'mkX a := x in a.
 
@@ -21,7 +21,7 @@ End GH5.
 
 Module GH10.
   Record X := mkX { A: nat; B: nat; x: bool; }.
-  Instance etaX : Settable _ := settable! mkX <A; B; x>.
+  #[export] Instance etaX : Settable _ := settable! mkX <A; B; x>.
 End GH10.
 
 Module GH13.
@@ -33,7 +33,7 @@ Module GH13.
                             Pc: word;
                           }.
 
-  Instance ThreadStateSettable : Settable ThreadState := settable! mkThreadState <Regs; Pc>.
+  #[export] Instance ThreadStateSettable : Settable ThreadState := settable! mkThreadState <Regs; Pc>.
 
   Definition test(s: ThreadState)(newRegs: Registers): ThreadState := s <| Regs := newRegs |>.
 

--- a/tests/SimpleRecordUpdate.v
+++ b/tests/SimpleRecordUpdate.v
@@ -28,11 +28,11 @@ My favorite running example, a simple record with three fields.
 With just the above definition, we would still need to implement the typeclass for every field of every record. Here's the particular form of implementation that we'll automate with this library.
 |*)
 
-  Instance setA : Setter A :=
+  #[export] Instance setA : Setter A :=
     fun (f:nat -> nat) (x:X) => mkX (f (A x)) (B x) (C x).
-  Instance setB : Setter B :=
+  #[export] Instance setB : Setter B :=
     fun (f:nat -> nat) (x:X) => mkX (A x) (f (B x)) (C x).
-  Instance setC : Setter C :=
+  #[export] Instance setC : Setter C :=
     fun (f:bool -> bool) (x:X) => mkX (A x) (B x) (f (C x)).
 End demo1.
 
@@ -53,7 +53,7 @@ Module demo2.
 Here's how we intend to implement `Settable`. This is equal to `fun x => x`, but we won't actually call `mkRecord`, instead we'll look up the implementation of `Settable` and actually look at the definition (rather than using the instances opaquely).
 |*)
 
-  Instance etaX : Settable X :=
+  #[export] Instance etaX : Settable X :=
     fun x => mkX (A x) (B x) (C x).
 End demo2.
 
@@ -139,7 +139,7 @@ Module demo4.
 Before we had to write out the expansion of X carefully; now we can just list out the constructor and fields:
 |*)
 
-  Instance etaX : Settable _ := settable! mkX <A;B;C>.
+  #[export] Instance etaX : Settable _ := settable! mkX <A;B;C>.
 End demo4.
 
 (*|
@@ -160,7 +160,7 @@ Module test.
                     B: nat;
                     C: unit }.
 
-  Instance eta : Settable X := settable! mkX <A;B;C>.
+  #[export] Instance eta : Settable X := settable! mkX <A;B;C>.
 
   Definition setAB a b x := x <|A := a|> <|B := b|>.
   Definition updateAB a b x := x <|A ::= plus a|> <|B ::= minus b|>.

--- a/tests/coqpl_2021.v
+++ b/tests/coqpl_2021.v
@@ -2,13 +2,13 @@ From RecordUpdate Require Import RecordUpdate.
 
 Record X := mkX { A: nat; B: nat; C: bool }.
 (* you can omit the X; it's there to clarify the Settable class for the paper *)
-Instance: Settable X := settable! mkX <A; B; C>.
+#[export] Instance: Settable X := settable! mkX <A; B; C>.
 
 Definition add3_to_B x := set B (plus 3) x.
 Definition setB_to_3 x := set B (fun _ => 3) x.
 Definition setB_to_3_notation x := x <|B:=3|>.
 
-Instance set_B : Setter B := _.
+#[export] Instance set_B : Setter B := _.
 
 Theorem set_B_convertible_to f x :
   set_B f x =
@@ -57,15 +57,15 @@ Definition nat1_synonym x := nat1 x.
 (* fails with a typechecking error, because the constructed identity function
 doesn't typecheck (we could do better by using tactics-in-terms to fail with a
 custom error message) *)
-Fail Instance: Settable _ := settable! Build_several_nats <nat1; nat3>.
+Fail #[export] Instance: Settable _ := settable! Build_several_nats <nat1; nat3>.
 (* fails because fields are out-of-order *)
-Fail Instance: Settable _ := settable! Build_several_nats <nat1; nat3; nat2>.
+Fail #[export] Instance: Settable _ := settable! Build_several_nats <nat1; nat3; nat2>.
 (* one of these just isn't a field, so the result isn't an identity function *)
-Fail Instance: Settable _ := settable! Build_several_nats <add2; nat2; nat3>.
+Fail #[export] Instance: Settable _ := settable! Build_several_nats <add2; nat2; nat3>.
 (* this isn't intentionally supported, but now we can only set nat1 via its
 synonym (actually, the only thing special about nat1 vs nat1_synonym is that Coq
 auto-generated nat1) *)
-Instance: Settable _ := settable! Build_several_nats <nat1_synonym; nat2; nat3>.
+#[export] Instance: Settable _ := settable! Build_several_nats <nat1_synonym; nat2; nat3>.
 
 (* this no longer works because the Settable several_nats doesn't say anything
 about nat1 *)


### PR DESCRIPTION
Fixes the instance locality deprecation warning (which was formerly suppressed in `_CoqProject`).