### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,9 @@ native_compute_profile_*.data
 
 # generated timing files
 *.timing.diff
-*.v.after-timing
-*.v.before-timing
-*.v.timing
+*.after-timing
+*.before-timing
+*.timing
 time-of-build-after.log
 time-of-build-before.log
 time-of-build-both.log


### PR DESCRIPTION
coq_makefile now generates .timing files without the .v