### PR TITLE
Update to Coq 8.19.0

### DIFF
--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         coq_image:
           - 'dev-ocaml-4.14-flambda'
+          - '8.19'
           - '8.18'
           - '8.17'
           - '8.16'

--- a/coq-record-update.opam
+++ b/coq-record-update.opam
@@ -20,7 +20,7 @@ simple typeclass that lists out the record fields."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.14" & < "8.19~") | (= "dev")}
+  "coq" {(>= "8.14" & < "8.20~") | (= "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
This PR updates the opam file to allows Coq 8.19. The tests pass locally. I am not sure how to run CI on this branch.