### PR TITLE
Fix large record field types blowing up search for SetterWf instance

### DIFF
--- a/src/RecordSet.v
+++ b/src/RecordSet.v
@@ -77,7 +77,7 @@ Local Ltac SetterWfInstance_t :=
       intros ? r; destruct r; reflexivity |
       let f := fresh in
       let r := fresh in
-      intros f r; destruct r; cbv; congruence ]
+      intros f r; destruct r; cbv [set]; cbn; congruence ]
   end.
 
 Global Hint Extern 1 (Setter _) => SetterInstance_t : typeclass_instances.


### PR DESCRIPTION
Performing `cbv` in the `set_eq` case on goals of the form

```
f (field {| field := r |}) = field {| field := r |} 
→ set field f {| field := r |} = {| field := r |}
```
blows up for large field types (like `r : gmap (bv 64) unit`). `cbv` only seems to be necessary to unfold `set`. `cbn` suffices for the outstanding beta reduction of the field projection.

Fixes #46 