### PR TITLE
flake support

### DIFF
--- a/.github/workflows/flake-build.yml
+++ b/.github/workflows/flake-build.yml
@@ -1,0 +1,27 @@
+name: Flake build
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v25
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - run: nix build
+    - run: nix flake check

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ time-of-build-after.log
 time-of-build-before.log
 time-of-build-both.log
 time-of-build-pretty.log
+
+# Nix-related build artifacts
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1725001927,
+        "narHash": "sha256-eV+63gK0Mp7ygCR0Oy4yIYSNcum2VQwnZamHxYTNi+M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6e99f2a27d600612004fbd2c3282d614bfee6421",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, flake-utils, ... }: let
+
+    coq-record-update = { lib, mkCoqDerivation, coq }: mkCoqDerivation rec {
+      pname = "coq-record-update";
+      defaultVersion = "0.3.4";
+      release."0.3.4" = {
+        src = lib.const (lib.cleanSourceWith {
+          src = lib.cleanSource ./.;
+          filter = let inherit (lib) hasSuffix; in path: type:
+            (! hasSuffix ".gitignore" path)
+            && (! hasSuffix "flake.nix" path)
+            && (! hasSuffix "flake.lock" path)
+            && (! hasSuffix "_build" path);
+        });
+      };
+    };
+
+  in flake-utils.lib.eachDefaultSystem (system: let
+    pkgs = import nixpkgs {
+      inherit system;
+      overlays = [ self.overlays.default ];
+    };
+  in {
+    devShells = {
+      coq-record-update = self.packages.${system}.coq-record-update;
+      default = self.packages.${system}.coq-record-update;
+    };
+
+    packages = {
+      coq-record-update = pkgs.coqPackages_8_19.coq-record-update;
+      default = self.packages.${system}.coq-record-update;
+    };
+  }) // {
+    # NOTE: To use this flake, apply the following overlay to nixpkgs and use
+    # the injected package from its respective coqPackages_VER attribute set!
+    overlays.default = final: prev: let
+      injectPkg = name: set:
+        prev.${name}.overrideScope (self: _: {
+          coq-record-update = self.callPackage coq-record-update {};
+        });
+    in (nixpkgs.lib.mapAttrs injectPkg {
+      inherit (final) coqPackages_8_19;
+    });
+  };
+}


### PR DESCRIPTION
Dear @tchajed,

Other projects such as [Aneris](https://github.com/logsem/aneris) depend on this library.
It would be great if it were available via Nix.
This PR makes this repo a Nix flake and as such adds Nix support.

The PR contains the following:
- a `flake.nix` file for building this project via `nix build` or opening a development environment via `nix develop`
- a `flake.lock` that pints the current versions of the flake's dependencies
- a `flake-build.yml` that adds testing this flake to your CI

Kind regards,
Sebastian.