### PR TITLE
use default way of specifying rocq version to docker-coq-action

### DIFF
--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -17,20 +17,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image:
-          - 'coqorg/coq:dev'
-          - 'coqorg/coq:8.19'
-          - 'coqorg/coq:8.18'
-          - 'coqorg/coq:8.17'
-          - 'coqorg/coq:8.15'
-          - 'coqorg/coq:8.14'
+        rocq_version:
+          - 'dev'
+          - '8.20'
+          - '8.19'
+          - '8.18'
+          - '8.17'
+          - '8.16'
+          - '8.15'
+          - '8.14'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: coq-community/docker-coq-action@v1
         with:
           opam_file: 'coq-record-update.opam'
-          custom_image: ${{ matrix.image }}
+          coq_version: ${{ matrix.rocq_version }}
 
 
 # See also:


### PR DESCRIPTION
coqorg/coq no longer has dev version