### PR TITLE
flake: update to NixOS 24.11 and Coq 8.20

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725001927,
-        "narHash": "sha256-eV+63gK0Mp7ygCR0Oy4yIYSNcum2VQwnZamHxYTNi+M=",
+        "lastModified": 1740417204,
+        "narHash": "sha256-2OoAzxdJN/SRDX3YuMHGHhvvsN6N5znpMS0DALRd18M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e99f2a27d600612004fbd2c3282d614bfee6421",
+        "rev": "3e866679c4cb67f6bf164d09c96fa8e21e25716e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-24.05",
+        "ref": "release-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs = { self, nixpkgs, flake-utils, ... }: let
@@ -32,7 +32,7 @@
     };
 
     packages = {
-      coq-record-update = pkgs.coqPackages_8_19.coq-record-update;
+      coq-record-update = pkgs.coqPackages_8_20.coq-record-update;
       default = self.packages.${system}.coq-record-update;
     };
   }) // {
@@ -44,7 +44,7 @@
           coq-record-update = self.callPackage coq-record-update {};
         });
     in (nixpkgs.lib.mapAttrs injectPkg {
-      inherit (final) coqPackages_8_19;
+      inherit (final) coqPackages_8_20;
     });
   };
 }


### PR DESCRIPTION
This updates the Nix flake to NixOS 24.11 and Coq 8.20.