### PR TITLE
Reduce set when applied to a constructor

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -18,7 +18,7 @@ test: $(TESTFILES:.v=.vo)
 .PHONY: test
 
 COQ_TEST=$(COQTOP) $(COQDEBUG) -batch -test-mode
-COQ_OLD=$(shell echo "$(COQ_VERSION)" | egrep "^8\.(8|9|10|11)\b" -q && echo 1)
+COQ_OLD=$(shell echo "$(COQ_VERSION)" | egrep "^8\.(14|15|16|17|18|19|20)\b" -q && echo 1)
 COQ_MINOR_VERSION:=$(shell echo "$(COQ_VERSION)" | egrep '^[0-9]+\.[0-9]+\b' -o)
 
 tests/.coqdeps.d: $(TESTFILES)

--- a/src/RecordSet.v
+++ b/src/RecordSet.v
@@ -53,7 +53,10 @@ Local Ltac get_setter T proj :=
 with correctness conditions that require the projected field and only the
 projected field is modified. *)
 Class Setter {R T} (proj: R -> T) := set : (T -> T) -> R -> R.
-Arguments set {R T} proj {Setter}.
+(* This command sets implicits and controls reduction behavior. [set] reduces
+under [simpl] and [cbn] if supplied all its arguments and the last argument (the
+record) is a constructor. *)
+#[global] Arguments set {R T} proj {Setter} _ !_ / : simpl nomatch.
 
 Class SetterWf {R T} (proj: R -> T) :=
   { set_wf : Setter proj;

--- a/tests/PrintingTests.ref
+++ b/tests/PrintingTests.ref
@@ -7,3 +7,13 @@ setXB = fun n : Nested => n <| anX; B := 3 |>
      : Nested -> Nested
 updateXB = fun n : Nested => n <| anX; B ::= S |>
      : Nested -> Nested
+1 goal
+  
+  ============================
+  {| anX := {| A := 2; B := 3 |}; aNat := 4 |} =
+  {| anX := {| A := 2; B := 3 |}; aNat := 4 |}
+1 goal
+  
+  ============================
+  {| anX := {| A := 3; B := 2 |}; aNat := 1 |} =
+  {| anX := {| A := 3; B := 2 |}; aNat := 1 |}

--- a/tests/PrintingTests.v
+++ b/tests/PrintingTests.v
@@ -17,3 +17,21 @@ Print setXB.
 
 Definition updateXB (n:Nested) := n <|anX; B::=S|>.
 Print updateXB.
+
+Lemma test_reduction :
+  (mkNested (mkX 2 3) 7) <|aNat := 4|> =
+  mkNested (mkX 2 3) 4.
+Proof.
+  (* this should reduce the LHS to the RHS *)
+  simpl. Show.
+  reflexivity.
+Qed.
+
+Lemma test_reduction2 :
+  (mkNested (mkX 2 3) 7) <|anX := mkX 3 2|> <|aNat := 1|> =
+  mkNested (mkX 3 2) 1.
+Proof.
+  (* this should reduce the LHS to the RHS *)
+  cbn. Show.
+  reflexivity.
+Qed.

--- a/tests/coqpl_2021.ref
+++ b/tests/coqpl_2021.ref
@@ -26,8 +26,8 @@ The command has indeed failed with message:
 In environment
 x : several_nats
 The term "Build_several_nats (nat1 x) (nat3 x)" has type
- "nat -> several_nats" while it is expected to have type 
-"several_nats".
+ "nat -> several_nats"
+while it is expected to have type "several_nats".
 The command has indeed failed with message:
 Tactic failure: incorrect settable! declaration (perhaps fields are out-of-order?).
 The command has indeed failed with message:


### PR DESCRIPTION
Reduce calls to `set` that are applied to a record which is a constructor, with both `simpl` and `cbn`.