### PR TITLE
Bump coq in coq-record-update.opam

### DIFF
--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -19,14 +19,13 @@ jobs:
       matrix:
         rocq_version:
           - 'dev'
+          - '9.2'
           - '9.1'
           - '8.20'
           - '8.19'
           - '8.18'
           - '8.17'
           - '8.16'
-          - '8.15'
-          - '8.14'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/coq-record-update.opam
+++ b/coq-record-update.opam
@@ -20,7 +20,7 @@ simple typeclass that lists out the record fields."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.14" & < "9.2") | (= "dev")}
+  "coq" {(>= "8.14" & < "9.3") | (= "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
The intent is to work around https://github.com/rocq-prover/stdlib/issues/256 and https://github.com/ocaml/opam-repository/pull/29675

I don't know enough opam to usefully test this, but I am trying build a project that uses coq-record-update and needs stdlib 9.1.